### PR TITLE
[Needle][constraint] Addition of the frictional constraint

### DIFF
--- a/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
@@ -29,9 +29,8 @@ public:
 
     virtual ConstraintNormal createConstraintNormal(const BaseProximity::SPtr & first, const BaseProximity::SPtr & second) const override {
         if (l_directions == NULL) return ConstraintNormal();
-        ConstraintNormal cst(l_directions->createConstraintsNormal(first, second)
-            .addOrthogonalDirection().addOrthogonalDirection());
-        return ConstraintNormal().add(cst[1]).add(cst[2]).add(cst[0]);
+        return l_directions->createConstraintsNormal(first, second)
+            .addOrthogonalDirection().addOrthogonalDirection();
     }
 
     core::behavior::ConstraintResolution* createConstraintResolution(const BaseInternalConstraint * cst) const {

--- a/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
@@ -10,13 +10,13 @@ class ConstraintInsertion : public TBaseConstraint<collisionAlgorithm::BaseProxi
 public:
     SOFA_CLASS(ConstraintInsertion , SOFA_TEMPLATE2(TBaseConstraint,BaseProximity,BaseProximity));
 
-    Data<SReal> d_frictionLimit;
+    Data<SReal> d_frictionCoeff;
     Data<sofa::type::vector<double> > d_maxForce;
     Data<sofa::type::vector<double> > d_compliance;
     core::objectmodel::SingleLink<ConstraintInsertion,ConstraintDirection, BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH> l_directions;
 
     ConstraintInsertion()
-    : d_frictionLimit(initData(&d_frictionLimit, 0.0, "frictionLimit" , "static friction force upper limit"))
+    : d_frictionCoeff(initData(&d_frictionCoeff, 0.0, "frictionCoeff" , "static friction coefficient (should be less than 1)"))
     , d_maxForce(initData(&d_maxForce, "maxForce", "Max force"))
     , d_compliance(initData(&d_compliance, "compliance", "Max force"))
     , l_directions(initLink("directions", "link to the default direction")) {}
@@ -46,7 +46,7 @@ public:
         if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
         if (d_compliance.getValue().size()>2) comp[2]=d_compliance.getValue()[2];
 
-        return new InsertionConstraintResolution(d_frictionLimit.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
+        return new InsertionConstraintResolution(d_frictionCoeff.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
 
         std::cerr << "Error the size of the constraint is not correct in ConstraintInsertion size=" << cst->size() << std::endl;
         return NULL;

--- a/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
@@ -10,12 +10,14 @@ class ConstraintInsertion : public TBaseConstraint<collisionAlgorithm::BaseProxi
 public:
     SOFA_CLASS(ConstraintInsertion , SOFA_TEMPLATE2(TBaseConstraint,BaseProximity,BaseProximity));
 
+    Data<SReal> d_friction;
     Data<sofa::type::vector<double> > d_maxForce;
     Data<sofa::type::vector<double> > d_compliance;
     core::objectmodel::SingleLink<ConstraintInsertion,ConstraintDirection, BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH> l_directions;
 
     ConstraintInsertion()
-    : d_maxForce(initData(&d_maxForce, "maxForce", "Max force"))
+    : d_friction(initData(&d_friction, 0.0, "mu" , "friction coefficient"))
+    , d_maxForce(initData(&d_maxForce, "maxForce", "Max force"))
     , d_compliance(initData(&d_compliance, "compliance", "Max force"))
     , l_directions(initLink("directions", "link to the default direction")) {}
 

--- a/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
@@ -10,13 +10,13 @@ class ConstraintInsertion : public TBaseConstraint<collisionAlgorithm::BaseProxi
 public:
     SOFA_CLASS(ConstraintInsertion , SOFA_TEMPLATE2(TBaseConstraint,BaseProximity,BaseProximity));
 
-    Data<SReal> d_friction;
+    Data<SReal> d_frictionLimit;
     Data<sofa::type::vector<double> > d_maxForce;
     Data<sofa::type::vector<double> > d_compliance;
     core::objectmodel::SingleLink<ConstraintInsertion,ConstraintDirection, BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH> l_directions;
 
     ConstraintInsertion()
-    : d_friction(initData(&d_friction, 0.0, "mu" , "friction coefficient"))
+    : d_frictionLimit(initData(&d_frictionLimit, 0.0, "frictionLimit" , "static friction force upper limit"))
     , d_maxForce(initData(&d_maxForce, "maxForce", "Max force"))
     , d_compliance(initData(&d_compliance, "compliance", "Max force"))
     , l_directions(initLink("directions", "link to the default direction")) {}
@@ -29,30 +29,30 @@ public:
 
     virtual ConstraintNormal createConstraintNormal(const BaseProximity::SPtr & first, const BaseProximity::SPtr & second) const override {
         if (l_directions == NULL) return ConstraintNormal();
-        ConstraintNormal cst(l_directions->createConstraintsNormal(first,second));
-        cst.addOrthogonalDirection().addOrthogonalDirection();
-        return ConstraintNormal().add(cst[1]).add(cst[2]);// l_directions->createConstraintsNormal(first, second);
+        ConstraintNormal cst(l_directions->createConstraintsNormal(first, second)
+            .addOrthogonalDirection().addOrthogonalDirection());
+        return ConstraintNormal().add(cst[1]).add(cst[2]).add(cst[0]);
     }
 
     core::behavior::ConstraintResolution* createConstraintResolution(const BaseInternalConstraint * cst) const {
-        if (cst->size() == 1) {
-            double maxf = std::numeric_limits<double>::max();
-            double comp = 0.0;
-            if (d_maxForce.getValue().size()>0) maxf=d_maxForce.getValue()[0];
-            if (d_compliance.getValue().size()>0) comp=d_compliance.getValue()[0];
-            return new InsertionConstraintResolution1(maxf,comp);
-        } else if (cst->size() == 2) {
-            double maxf[2] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
-            double comp[2] = { 0.0, 0.0 };
+        //if (cst->size() == 1) {
+        //    double maxf = std::numeric_limits<double>::max();
+        //    double comp = 0.0;
+        //    if (d_maxForce.getValue().size()>0) maxf=d_maxForce.getValue()[0];
+        //    if (d_compliance.getValue().size()>0) comp=d_compliance.getValue()[0];
+        //    return new InsertionConstraintResolution1(maxf,comp);
+        //} else if (cst->size() == 2) {
+        //    double maxf[2] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
+        //    double comp[2] = { 0.0, 0.0 };
 
-            if (d_maxForce.getValue().size()>0) maxf[0]=d_maxForce.getValue()[0];
-            if (d_maxForce.getValue().size()>1) maxf[1]=d_maxForce.getValue()[1];
+        //    if (d_maxForce.getValue().size()>0) maxf[0]=d_maxForce.getValue()[0];
+        //    if (d_maxForce.getValue().size()>1) maxf[1]=d_maxForce.getValue()[1];
 
-            if (d_compliance.getValue().size()>0) comp[0]=d_compliance.getValue()[0];
-            if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
+        //    if (d_compliance.getValue().size()>0) comp[0]=d_compliance.getValue()[0];
+        //    if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
 
-            return new InsertionConstraintResolution2(maxf[0],maxf[1],comp[0],comp[1]);
-        } else if (cst->size() == 3) {
+        //    return new InsertionConstraintResolution2(maxf[0],maxf[1],comp[0],comp[1]);
+        //} else if (cst->size() == 3) {
 
             double maxf[3] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
             double comp[3] = { 0.0, 0.0, 0.0 };
@@ -65,8 +65,8 @@ public:
             if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
             if (d_compliance.getValue().size()>2) comp[2]=d_compliance.getValue()[2];
 
-            return new InsertionConstraintResolution3(maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
-        }
+            return new InsertionConstraintResolution(d_frictionLimit.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
+        //}
 
         std::cerr << "Error the size of the constraint is not correct in ConstraintInsertion size=" << cst->size() << std::endl;
         return NULL;

--- a/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/sofa/constraintGeometry/constraint/ConstraintInsertion.h
@@ -35,38 +35,18 @@ public:
     }
 
     core::behavior::ConstraintResolution* createConstraintResolution(const BaseInternalConstraint * cst) const {
-        //if (cst->size() == 1) {
-        //    double maxf = std::numeric_limits<double>::max();
-        //    double comp = 0.0;
-        //    if (d_maxForce.getValue().size()>0) maxf=d_maxForce.getValue()[0];
-        //    if (d_compliance.getValue().size()>0) comp=d_compliance.getValue()[0];
-        //    return new InsertionConstraintResolution1(maxf,comp);
-        //} else if (cst->size() == 2) {
-        //    double maxf[2] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
-        //    double comp[2] = { 0.0, 0.0 };
+        double maxf[3] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
+        double comp[3] = { 0.0, 0.0, 0.0 };
 
-        //    if (d_maxForce.getValue().size()>0) maxf[0]=d_maxForce.getValue()[0];
-        //    if (d_maxForce.getValue().size()>1) maxf[1]=d_maxForce.getValue()[1];
+        if (d_maxForce.getValue().size()>0) maxf[0]=d_maxForce.getValue()[0];
+        if (d_maxForce.getValue().size()>1) maxf[1]=d_maxForce.getValue()[1];
+        if (d_maxForce.getValue().size()>2) maxf[2]=d_maxForce.getValue()[2];
 
-        //    if (d_compliance.getValue().size()>0) comp[0]=d_compliance.getValue()[0];
-        //    if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
+        if (d_compliance.getValue().size()>0) comp[0]=d_compliance.getValue()[0];
+        if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
+        if (d_compliance.getValue().size()>2) comp[2]=d_compliance.getValue()[2];
 
-        //    return new InsertionConstraintResolution2(maxf[0],maxf[1],comp[0],comp[1]);
-        //} else if (cst->size() == 3) {
-
-            double maxf[3] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
-            double comp[3] = { 0.0, 0.0, 0.0 };
-
-            if (d_maxForce.getValue().size()>0) maxf[0]=d_maxForce.getValue()[0];
-            if (d_maxForce.getValue().size()>1) maxf[1]=d_maxForce.getValue()[1];
-            if (d_maxForce.getValue().size()>2) maxf[2]=d_maxForce.getValue()[2];
-
-            if (d_compliance.getValue().size()>0) comp[0]=d_compliance.getValue()[0];
-            if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
-            if (d_compliance.getValue().size()>2) comp[2]=d_compliance.getValue()[2];
-
-            return new InsertionConstraintResolution(d_frictionLimit.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
-        //}
+        return new InsertionConstraintResolution(d_frictionLimit.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
 
         std::cerr << "Error the size of the constraint is not correct in ConstraintInsertion size=" << cst->size() << std::endl;
         return NULL;

--- a/src/sofa/constraintGeometry/constraint/InsertionResolution.h
+++ b/src/sofa/constraintGeometry/constraint/InsertionResolution.h
@@ -8,68 +8,6 @@ namespace sofa {
 
 namespace constraintGeometry {
 
-//class InsertionConstraintResolution1 : public sofa::core::behavior::ConstraintResolution {
-//public:
-//    InsertionConstraintResolution1(double maxf1 = std::numeric_limits<double>::max(), double comp1 = 0.0) : sofa::core::behavior::ConstraintResolution(1) {
-//        m_maxForce = maxf1;
-//
-//        m_compliance = comp1;
-//    }
-//
-//    virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/) {
-//        force[line] -= d[line] / (w[line][line] + m_compliance);
-//        if (force[line] > m_maxForce) force[line]=m_maxForce;
-//        if (force[line] < -m_maxForce) force[line]=-m_maxForce;
-//    }
-//
-//    double m_compliance;
-//    double m_maxForce;
-//};
-//
-//class InsertionConstraintResolution2 : public sofa::core::behavior::ConstraintResolution {
-//public:
-//    InsertionConstraintResolution2(double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),
-//                                   double comp1 = 0.0,double comp2 = 0.0) : sofa::core::behavior::ConstraintResolution(2) {
-//        m_maxForce[0] = maxf1;
-//        m_maxForce[1] = maxf2;
-//
-//        m_compliance[0] = comp1;
-//        m_compliance[1] = comp2;
-//    }
-//
-//    virtual void init(int line, double** w, double * /*force*/)
-//    {
-//        sofa::type::Mat<2,2,double> temp;
-//        for (unsigned j=0;j<2;j++) {
-//            for (unsigned i=0;i<2;i++) {
-//                temp[j][i] = w[line+j][line+i];
-//
-//                if (i == j) temp[j][i]+=m_compliance[i];
-//            }
-//        }
-//
-//        SOFA_UNUSED(sofa::type::invertMatrix(invW,temp));
-//    }
-//
-//    virtual void resolution(int line, double** /*w*/, double* d, double* force, double * /*dFree*/)
-//    {
-//        for(int i=0; i<2; i++) {
-//            for(int j=0; j<2; j++)
-//                force[line+i] -= d[line+j] * invW[i][j];
-//        }
-//
-//        for(int i=0; i<2; i++) {
-//            if (force[line+i] > m_maxForce[i]) force[line+i]=m_maxForce[i];
-//            else if (force[line+i] < -m_maxForce[i]) force[line+i]=-m_maxForce[i];
-//        }
-//    }
-//
-//    double m_maxForce[2];
-//    double m_compliance[2];
-//    sofa::type::Mat<2,2,double> invW;
-//};
-
-
 class InsertionConstraintResolution : public sofa::core::behavior::ConstraintResolution {
 public:
     InsertionConstraintResolution(SReal frictionLimit, double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),double maxf3 = std::numeric_limits<double>::max(),

--- a/src/sofa/constraintGeometry/constraint/InsertionResolution.h
+++ b/src/sofa/constraintGeometry/constraint/InsertionResolution.h
@@ -8,71 +8,71 @@ namespace sofa {
 
 namespace constraintGeometry {
 
-class InsertionConstraintResolution1 : public sofa::core::behavior::ConstraintResolution {
+//class InsertionConstraintResolution1 : public sofa::core::behavior::ConstraintResolution {
+//public:
+//    InsertionConstraintResolution1(double maxf1 = std::numeric_limits<double>::max(), double comp1 = 0.0) : sofa::core::behavior::ConstraintResolution(1) {
+//        m_maxForce = maxf1;
+//
+//        m_compliance = comp1;
+//    }
+//
+//    virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/) {
+//        force[line] -= d[line] / (w[line][line] + m_compliance);
+//        if (force[line] > m_maxForce) force[line]=m_maxForce;
+//        if (force[line] < -m_maxForce) force[line]=-m_maxForce;
+//    }
+//
+//    double m_compliance;
+//    double m_maxForce;
+//};
+//
+//class InsertionConstraintResolution2 : public sofa::core::behavior::ConstraintResolution {
+//public:
+//    InsertionConstraintResolution2(double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),
+//                                   double comp1 = 0.0,double comp2 = 0.0) : sofa::core::behavior::ConstraintResolution(2) {
+//        m_maxForce[0] = maxf1;
+//        m_maxForce[1] = maxf2;
+//
+//        m_compliance[0] = comp1;
+//        m_compliance[1] = comp2;
+//    }
+//
+//    virtual void init(int line, double** w, double * /*force*/)
+//    {
+//        sofa::type::Mat<2,2,double> temp;
+//        for (unsigned j=0;j<2;j++) {
+//            for (unsigned i=0;i<2;i++) {
+//                temp[j][i] = w[line+j][line+i];
+//
+//                if (i == j) temp[j][i]+=m_compliance[i];
+//            }
+//        }
+//
+//        SOFA_UNUSED(sofa::type::invertMatrix(invW,temp));
+//    }
+//
+//    virtual void resolution(int line, double** /*w*/, double* d, double* force, double * /*dFree*/)
+//    {
+//        for(int i=0; i<2; i++) {
+//            for(int j=0; j<2; j++)
+//                force[line+i] -= d[line+j] * invW[i][j];
+//        }
+//
+//        for(int i=0; i<2; i++) {
+//            if (force[line+i] > m_maxForce[i]) force[line+i]=m_maxForce[i];
+//            else if (force[line+i] < -m_maxForce[i]) force[line+i]=-m_maxForce[i];
+//        }
+//    }
+//
+//    double m_maxForce[2];
+//    double m_compliance[2];
+//    sofa::type::Mat<2,2,double> invW;
+//};
+
+
+class InsertionConstraintResolution : public sofa::core::behavior::ConstraintResolution {
 public:
-    InsertionConstraintResolution1(double maxf1 = std::numeric_limits<double>::max(), double comp1 = 0.0) : sofa::core::behavior::ConstraintResolution(1) {
-        m_maxForce = maxf1;
-
-        m_compliance = comp1;
-    }
-
-    virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/) {
-        force[line] -= d[line] / (w[line][line] + m_compliance);
-        if (force[line] > m_maxForce) force[line]=m_maxForce;
-        if (force[line] < -m_maxForce) force[line]=-m_maxForce;
-    }
-
-    double m_compliance;
-    double m_maxForce;
-};
-
-class InsertionConstraintResolution2 : public sofa::core::behavior::ConstraintResolution {
-public:
-    InsertionConstraintResolution2(double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),
-                                   double comp1 = 0.0,double comp2 = 0.0) : sofa::core::behavior::ConstraintResolution(2) {
-        m_maxForce[0] = maxf1;
-        m_maxForce[1] = maxf2;
-
-        m_compliance[0] = comp1;
-        m_compliance[1] = comp2;
-    }
-
-    virtual void init(int line, double** w, double * /*force*/)
-    {
-        sofa::type::Mat<2,2,double> temp;
-        for (unsigned j=0;j<2;j++) {
-            for (unsigned i=0;i<2;i++) {
-                temp[j][i] = w[line+j][line+i];
-
-                if (i == j) temp[j][i]+=m_compliance[i];
-            }
-        }
-
-        SOFA_UNUSED(sofa::type::invertMatrix(invW,temp));
-    }
-
-    virtual void resolution(int line, double** /*w*/, double* d, double* force, double * /*dFree*/)
-    {
-        for(int i=0; i<2; i++) {
-            for(int j=0; j<2; j++)
-                force[line+i] -= d[line+j] * invW[i][j];
-        }
-
-        for(int i=0; i<2; i++) {
-            if (force[line+i] > m_maxForce[i]) force[line+i]=m_maxForce[i];
-            else if (force[line+i] < -m_maxForce[i]) force[line+i]=-m_maxForce[i];
-        }
-    }
-
-    double m_maxForce[2];
-    double m_compliance[2];
-    sofa::type::Mat<2,2,double> invW;
-};
-
-
-class InsertionConstraintResolution3 : public sofa::core::behavior::ConstraintResolution {
-public:
-    InsertionConstraintResolution3(double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),double maxf3 = std::numeric_limits<double>::max(),
+    InsertionConstraintResolution(SReal frictionLimit, double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),double maxf3 = std::numeric_limits<double>::max(),
                                    double comp1 = 0.0,double comp2 = 0.0,double comp3 = 0.0) : sofa::core::behavior::ConstraintResolution(3) {
         m_maxForce[0] = maxf1;
         m_maxForce[1] = maxf2;
@@ -81,6 +81,8 @@ public:
         m_compliance[0] = comp1;
         m_compliance[1] = comp2;
         m_compliance[2] = comp3;
+
+        m_frictionLimit = frictionLimit;
     }
 
     virtual void init(int line, double** w, double * /*force*/)
@@ -97,22 +99,42 @@ public:
         SOFA_UNUSED(sofa::type::invertMatrix(invW,temp));
     }
 
-    virtual void resolution(int line, double** /*w*/, double* d, double* force, double * /*dFree*/)
+    virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/)
     {
-        for(int i=0; i<3; i++) {
-            for(int j=0; j<3; j++)
-                force[line+i] -= d[line+j] * invW[i][j];
-        }
+        //we solve the first two bilateral constraints
+        double inv;
+        inv=1.0/(w[line][line]);
+        double corr0 = -inv * d[line+0];
+        force[line+0] += corr0;
 
-        for(int i=0; i<3; i++) {
+        d[line+1] += w[line+1][line+0] * corr0;
+        inv=1.0/(w[line+1][line+1]);
+        double corr1= -inv * d[line+1];
+        force[line+1] += corr1;
+
+        for(int i=0; i<2; i++) {
             if (force[line+i] > m_maxForce[i]) force[line+i]=m_maxForce[i];
             else if (force[line+i] < -m_maxForce[i]) force[line+i]=-m_maxForce[i];
         }
+
+        // then solve for the frictional constraint
+        d[line+2] += w[line+2][line+0] * corr0 + w[line+2][line+1] * corr1;
+        inv=1.0/(w[line+2][line+2]);
+        double corr2= -inv * d[line+2];
+        force[line+2] += corr2;
+
+        SReal slip_force = m_frictionLimit;
+        if (force[line+2] >  slip_force) force[line+2] = slip_force;
+        else if (force[line+2] < -slip_force) force[line+2] = -slip_force;
+
+        if (force[line+2] > m_maxForce[2]) force[line+2]=m_maxForce[2];
+        else if (force[line+2] < -m_maxForce[2]) force[line+2]=-m_maxForce[2];
     }
 
     double m_maxForce[3];
     double m_compliance[3];
     sofa::type::Mat<3,3,double> invW;
+    SReal m_frictionLimit;
 };
 
 }

--- a/src/sofa/constraintGeometry/constraint/InsertionResolution.h
+++ b/src/sofa/constraintGeometry/constraint/InsertionResolution.h
@@ -10,7 +10,7 @@ namespace constraintGeometry {
 
 class InsertionConstraintResolution : public sofa::core::behavior::ConstraintResolution {
 public:
-    InsertionConstraintResolution(SReal frictionLimit, double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),double maxf3 = std::numeric_limits<double>::max(),
+    InsertionConstraintResolution(SReal frictionCoeff, double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),double maxf3 = std::numeric_limits<double>::max(),
                                    double comp1 = 0.0,double comp2 = 0.0,double comp3 = 0.0) : sofa::core::behavior::ConstraintResolution(3) {
         m_maxForce[0] = maxf1;
         m_maxForce[1] = maxf2;
@@ -20,7 +20,7 @@ public:
         m_compliance[1] = comp2;
         m_compliance[2] = comp3;
 
-        m_frictionLimit = frictionLimit;
+        m_frictionCoeff = frictionCoeff;
     }
 
     virtual void init(int line, double** w, double * /*force*/)
@@ -61,7 +61,7 @@ public:
         double corr2= -inv * d[line+2];
         force[line+2] += corr2;
 
-        SReal slip_force = m_frictionLimit;
+        SReal slip_force = m_frictionCoeff;
         if (force[line+2] >  slip_force) force[line+2] = slip_force;
         else if (force[line+2] < -slip_force) force[line+2] = -slip_force;
 
@@ -72,7 +72,7 @@ public:
     double m_maxForce[3];
     double m_compliance[3];
     sofa::type::Mat<3,3,double> invW;
-    SReal m_frictionLimit;
+    SReal m_frictionCoeff;
 };
 
 }


### PR DESCRIPTION
## Dependencies

PR https://github.com/InfinyTech3D/CollisionAlgorithm/pull/36 is concurrent and should be merged together with this one.

## Additions

- The InsertionResolution class solves a 3x3 block system to satisfy the bilateral constraints and add friction to the system.
    1. Frictional force is computed as it would in case of a bilateral constraint.
    2. The friction coefficient is used to attenuate and reduce it.
    3. The bilateral constraint problem is resolved after fixing the frictional force.
- The ConstraintInsertion class provides the 3 normal directions

## Issues

Closes #7 