### PR TITLE
[src] Update inheritance of plugin components from BaseLagrangianContraint  to follow refactoring done in SOFA

### DIFF
--- a/src/sofa/constraintGeometry/BaseConstraint.h
+++ b/src/sofa/constraintGeometry/BaseConstraint.h
@@ -2,7 +2,7 @@
 
 #include <sofa/collisionAlgorithm/BaseAlgorithm.h>
 #include <sofa/collisionAlgorithm/BaseGeometry.h>
-#include <sofa/core/behavior/BaseConstraint.h>
+#include <sofa/core/behavior/BaseLagrangianConstraint.h>
 #include <sofa/collisionAlgorithm/BaseProximity.h>
 #include <sofa/constraintGeometry/ConstraintNormal.h>
 #include <sofa/constraintGeometry/InternalConstraint.h>
@@ -12,7 +12,7 @@
 namespace sofa::constraintGeometry {
 
 
-class BaseConstraint : public sofa::core::behavior::BaseConstraint{
+class BaseConstraint : public sofa::core::behavior::BaseLagrangianConstraint{
 public:
 
     virtual ~BaseConstraint(){}
@@ -33,12 +33,12 @@ public:
 
 
 /*!
- * \brief The BaseConstraint abstract class is the implementation of sofa's abstract BaseConstraint
+ * \brief The BaseConstraint abstract class is the implementation of sofa's abstract BaseLagrangianConstraint
  */
 template<class FIRST = collisionAlgorithm::BaseProximity, class SECOND = collisionAlgorithm::BaseProximity>
 class TBaseConstraint : public BaseConstraint {
 public:
-    SOFA_CLASS(BaseConstraint, sofa::core::behavior::BaseConstraint);
+    SOFA_CLASS(BaseConstraint, sofa::core::behavior::BaseLagrangianConstraint);
 
     typedef collisionAlgorithm::BaseProximity BaseProximity;
 

--- a/src/sofa/constraintGeometry/ConstraintDirection.h
+++ b/src/sofa/constraintGeometry/ConstraintDirection.h
@@ -2,14 +2,14 @@
 
 #include <sofa/collisionAlgorithm/BaseAlgorithm.h>
 #include <sofa/collisionAlgorithm/BaseGeometry.h>
-#include <sofa/core/behavior/BaseConstraint.h>
+#include <sofa/core/behavior/BaseLagrangianConstraint.h>
 #include <sofa/constraintGeometry/ConstraintNormal.h>
 #include <sofa/constraintGeometry/InternalConstraint.h>
 
 namespace sofa::constraintGeometry {
 
 /*!
- * \brief The BaseConstraint abstract class is the implementation of sofa's abstract BaseConstraint
+ * \brief The BaseConstraint abstract class is the implementation of sofa's abstract BaseLagrangianConstraint
  */
 class ConstraintDirection : public sofa::core::objectmodel::BaseObject {
 public:

--- a/src/sofa/constraintGeometry/ConstraintResponse.h
+++ b/src/sofa/constraintGeometry/ConstraintResponse.h
@@ -2,7 +2,7 @@
 
 #include <sofa/collisionAlgorithm/BaseAlgorithm.h>
 #include <sofa/collisionAlgorithm/BaseGeometry.h>
-#include <sofa/core/behavior/BaseConstraint.h>
+#include <sofa/core/behavior/BaseLagrangianConstraint.h>
 #include <sofa/constraintGeometry/ConstraintNormal.h>
 #include <sofa/constraintGeometry/InternalConstraint.h>
 
@@ -11,7 +11,7 @@ namespace sofa {
 namespace constraintGeometry {
 
 /*!
- * \brief The BaseConstraint abstract class is the implementation of sofa's abstract BaseConstraint
+ * \brief The BaseConstraint abstract class is the implementation of sofa's abstract BaseLagrangianConstraint
  */
 class ConstraintResponse : public sofa::core::objectmodel::BaseObject {
 public:


### PR DESCRIPTION
The `BaseConstraint.h` header has been deprecated in SOFA. Same with the `sofa::core::behavior::BaseConstraint`.
To keep up-to-date with SOFA, all relevant components should inherit from `sofa::core::behavior::BaseLagrangianConstraint`.
Closes #16 