### PR TITLE
[ci] Add non-regression tests from CollisionAlgorithm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,17 +122,55 @@ jobs:
             echo "$WORKSPACE_ARTIFACT_PATH/lib" >> $GITHUB_PATH
             echo "$WORKSPACE_ARTIFACT_PATH/bin" >> $GITHUB_PATH
             echo "$SOFA_ROOT/plugins/SofaPython3/bin" >> $GITHUB_PATH
-            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/bin" | tee -a $GITHUB_ENV
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/bin;$GITHUB_WORKSPACE/deps/CollisionAlgorithm/install/bin" | tee -a $GITHUB_ENV
           else
-            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/lib" | tee -a $GITHUB_ENV
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$GITHUB_WORKSPACE/deps/CollisionAlgorithm/install/lib" | tee -a $GITHUB_ENV
           fi
 
           if [[ "$RUNNER_OS" == "macOS" ]]; then
-            echo "DYLD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$SOFA_ROOT/plugins/SofaPython3/lib:$DYLD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+            echo "DYLD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$GITHUB_WORKSPACE/deps/CollisionAlgorithm/install/lib:$SOFA_ROOT/plugins/SofaPython3/lib:$DYLD_LIBRARY_PATH" | tee -a $GITHUB_ENV
           fi
 
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            echo "LD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$SOFA_ROOT/plugins/SofaPython3/lib:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+            echo "LD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$GITHUB_WORKSPACE/deps/CollisionAlgorithm/install/lib:$SOFA_ROOT/plugins/SofaPython3/lib:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+          fi
+          ls -R $GITHUB_WORKSPACE/deps/CollisionAlgorithm/
+
+      # - name: Check environment for tests
+      #   shell: bash
+      #   run: |
+      #     echo '------ ls -la "$WORKSPACE_SRC_PATH" ------'
+      #     ls -la "$WORKSPACE_SRC_PATH"
+      #     echo '------ ls -la "$WORKSPACE_BUILD_PATH" ------'
+      #     ls -la "$WORKSPACE_BUILD_PATH"
+      #     echo '------ ls -la "$WORKSPACE_INSTALL_PATH" ------'
+      #     ls -la "$WORKSPACE_INSTALL_PATH"
+      #     echo '------ ls -la "$WORKSPACE_ARTIFACT_PATH" ------'
+      #     ls -la "$WORKSPACE_ARTIFACT_PATH"
+      #     echo '----------------------'
+      #     echo "SOFA_ROOT = $SOFA_ROOT"
+
+      - name: Fetch, install and run Regression_test
+        id: regression-test
+        if: always()
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" != "macOS" ]]; then
+            # Get regression from github releases
+            mkdir -p "${{ runner.temp }}/regression_tmp/install"
+            curl --output "${{ runner.temp }}/regression_tmp/${RUNNER_OS}.zip" -L https://github.com/sofa-framework/regression/releases/download/release-master/Regression_test_master_for-SOFA-${{ steps.sofa.outputs.sofa_version }}_${RUNNER_OS}.zip
+            unzip -qq "${{ runner.temp }}/regression_tmp/${RUNNER_OS}.zip" -d "${{ runner.temp }}/regression_tmp/install"
+            # Install it in the SOFA bin directory
+            $SUDO mv "${{ runner.temp }}"/regression_tmp/install/Regression_*/bin/* "${SOFA_ROOT}/bin"
+            chmod +x ${SOFA_ROOT}/bin/Regression_test${{ steps.sofa.outputs.exe }}
+            # Setup mandatory env vars
+            export REGRESSION_SCENES_DIR="${GITHUB_WORKSPACE}/deps/CollisionAlgorithm/scenes"
+            export REGRESSION_REFERENCES_DIR="${GITHUB_WORKSPACE}/deps/CollisionAlgorithm/regression/references"
+            export PYTHONPATH=$SOFA_ROOT/plugins/SofaPython3/lib/python3/site-packages
+            # Run regression test bench
+            ${SOFA_ROOT}/bin/Regression_test${{ steps.sofa.outputs.exe }}
+          else
+            echo "Regression tests are not supported on the CI for macOS yet (TODO)"
           fi
 
   deploy:


### PR DESCRIPTION
This PR updates the CI to run the non-regression tests from CollisionAlgorithm.
Because the two repositories are closely coupled, it is safer to run these tests whenever changes are made in either repository.

This PR is based on https://github.com/InfinyTech3D/CollisionAlgorithm/pull/87. Without it, the CollisionAlgorithm has no regression folder.