### PR TITLE
[constraint] Add the option to normalize the compliance block matrix before inversion

### DIFF
--- a/src/ConstraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/ConstraintGeometry/constraint/ConstraintInsertion.h
@@ -13,12 +13,14 @@ public:
     Data<SReal> d_frictionCoeff;
     Data<sofa::type::vector<double> > d_maxForce;
     Data<sofa::type::vector<double> > d_compliance;
+    Data<bool> d_scaleComplianceMatrix;
     core::objectmodel::SingleLink<ConstraintInsertion,ConstraintDirection, BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH> l_directions;
 
     ConstraintInsertion()
     : d_frictionCoeff(initData(&d_frictionCoeff, 0.0, "frictionCoeff" , "static friction coefficient (should be less than 1)"))
     , d_maxForce(initData(&d_maxForce, "maxForce", "Max force"))
     , d_compliance(initData(&d_compliance, "compliance", "Max force"))
+    , d_scaleComplianceMatrix(initData(&d_scaleComplianceMatrix, false, "scaleComplianceMatrix", "If true, normalize the compliance matrix by the mean of its diagonal before inverting it, then rescale the inverse. Leaves the inverse mathematically unchanged, but prevents invertMatrix from rejecting a well-conditioned matrix whose entries are of a low magnitude"))
     , l_directions(initLink("directions", "link to the default direction")) {}
 
     void init() { // make sure we have a direction
@@ -45,7 +47,8 @@ public:
         if (d_compliance.getValue().size()>1) comp[1]=d_compliance.getValue()[1];
         if (d_compliance.getValue().size()>2) comp[2]=d_compliance.getValue()[2];
 
-        return new InsertionConstraintResolution(d_frictionCoeff.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2]);
+        return new InsertionConstraintResolution(d_frictionCoeff.getValue(), maxf[0],maxf[1],maxf[2],comp[0],comp[1],comp[2],
+                                                 d_scaleComplianceMatrix.getValue());
 
         std::cerr << "Error the size of the constraint is not correct in ConstraintInsertion size=" << cst->size() << std::endl;
         return NULL;

--- a/src/ConstraintGeometry/constraint/ConstraintInsertion.h
+++ b/src/ConstraintGeometry/constraint/ConstraintInsertion.h
@@ -20,7 +20,8 @@ public:
     : d_frictionCoeff(initData(&d_frictionCoeff, 0.0, "frictionCoeff" , "static friction coefficient (should be less than 1)"))
     , d_maxForce(initData(&d_maxForce, "maxForce", "Max force"))
     , d_compliance(initData(&d_compliance, "compliance", "Max force"))
-    , d_scaleComplianceMatrix(initData(&d_scaleComplianceMatrix, false, "scaleComplianceMatrix", "If true, normalize the compliance matrix by the mean of its diagonal before inverting it, then rescale the inverse. Leaves the inverse mathematically unchanged, but prevents invertMatrix from rejecting a well-conditioned matrix whose entries are of a low magnitude"))
+    , d_scaleComplianceMatrix(initData(&d_scaleComplianceMatrix, false, "scaleComplianceMatrix"
+                , "If true, normalize the compliance matrix by the mean of its diagonal before inversion"))
     , l_directions(initLink("directions", "link to the default direction")) {}
 
     void init() { // make sure we have a direction

--- a/src/ConstraintGeometry/constraint/InsertionResolution.h
+++ b/src/ConstraintGeometry/constraint/InsertionResolution.h
@@ -3,6 +3,7 @@
 #include <ConstraintGeometry/BaseConstraint.h>
 #include <ConstraintGeometry/directions/BindDirection.h>
 #include <sofa/core/behavior/ConstraintResolution.h>
+#include <sofa/helper/logging/Messaging.h>
 #include <cmath>
 
 namespace sofa {
@@ -39,11 +40,10 @@ public:
 
         bool inverted = sofa::type::invertMatrix(invW, temp);
 
-        // invertMatrix rejects on |det| < machine-eps returning zeros. The scale of the entries in
-        // this matrix block depend on the physical parameters in the scene. Depending on scene
-        // configuration, a matrix can be generated which may get rejected by invertMatrix due to
-        // its scale even though it may be well-conditioned. The matrix can be optionally scaled
-        // with the diagonal mean to avoid this.
+        // invertMatrix rejects the inversion if |det| < machine-eps, leaves invW empty and returns 
+        // false. However, |det| depends on the problem scale and the physical parameters. 
+        // It can happen that a matrix is well-conditioned but with a small |det|. In that case, 
+        // proceed by scaling the matrix before inversion, then scale it back up afterwards.
         if (!inverted && m_scaleComplianceMatrix)
         {
             const double s = (std::abs(temp[0][0]) + std::abs(temp[1][1]) + std::abs(temp[2][2])) / 3.0;
@@ -51,11 +51,14 @@ public:
             {
                 const double invS = 1.0 / s;
                 inverted = sofa::type::invertMatrix(invW, temp * invS);
-                if (inverted) invW *= invS;
+                invW *= invS;
             }
         }
 
-        SOFA_UNUSED(inverted);
+        // Matrix is rank-deficient. Nothing could be done.
+        if (!inverted)
+            msg_warning("InsertionConstraintResolution")
+                << "Failed to invert the compliance matrix of the constraint at line " << line << ".";
     }
 
     virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/)

--- a/src/ConstraintGeometry/constraint/InsertionResolution.h
+++ b/src/ConstraintGeometry/constraint/InsertionResolution.h
@@ -58,7 +58,7 @@ public:
         // Matrix is rank-deficient. Nothing could be done.
         if (!inverted)
             msg_warning("InsertionConstraintResolution")
-                << "Failed to invert the compliance matrix of the constraint at line " << line << ".";
+                << "Failed to invert the compliance matrix of the constraint at line " << line << ". If not already done, try to scale compliance matrix using Data scaleComplianceMatrix";
     }
 
     virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/)

--- a/src/ConstraintGeometry/constraint/InsertionResolution.h
+++ b/src/ConstraintGeometry/constraint/InsertionResolution.h
@@ -3,6 +3,7 @@
 #include <ConstraintGeometry/BaseConstraint.h>
 #include <ConstraintGeometry/directions/BindDirection.h>
 #include <sofa/core/behavior/ConstraintResolution.h>
+#include <cmath>
 
 namespace sofa {
 
@@ -11,7 +12,8 @@ namespace constraintgeometry {
 class InsertionConstraintResolution : public sofa::core::behavior::ConstraintResolution {
 public:
     InsertionConstraintResolution(SReal frictionCoeff, double maxf1 = std::numeric_limits<double>::max(),double maxf2 = std::numeric_limits<double>::max(),double maxf3 = std::numeric_limits<double>::max(),
-                                   double comp1 = 0.0,double comp2 = 0.0,double comp3 = 0.0) : sofa::core::behavior::ConstraintResolution(3) {
+                                   double comp1 = 0.0,double comp2 = 0.0,double comp3 = 0.0,
+                                   bool scaleComplianceMatrix = false) : sofa::core::behavior::ConstraintResolution(3) {
         m_maxForce[0] = maxf1;
         m_maxForce[1] = maxf2;
         m_maxForce[2] = maxf3;
@@ -21,6 +23,7 @@ public:
         m_compliance[2] = comp3;
 
         m_frictionCoeff = frictionCoeff;
+        m_scaleComplianceMatrix = scaleComplianceMatrix;
     }
 
     virtual void init(int line, double** w, double * /*force*/)
@@ -34,7 +37,25 @@ public:
             }
         }
 
-        SOFA_UNUSED(sofa::type::invertMatrix(invW,temp));
+        bool inverted = sofa::type::invertMatrix(invW, temp);
+
+        // invertMatrix rejects on |det| < machine-eps returning zeros. The scale of the entries in
+        // this matrix block depend on the physical parameters in the scene. Depending on scene
+        // configuration, a matrix can be generated which may get rejected by invertMatrix due to
+        // its scale even though it may be well-conditioned. The matrix can be optionally scaled
+        // with the diagonal mean to avoid this.
+        if (!inverted && m_scaleComplianceMatrix)
+        {
+            const double s = (std::abs(temp[0][0]) + std::abs(temp[1][1]) + std::abs(temp[2][2])) / 3.0;
+            if (s > 0.0)
+            {
+                const double invS = 1.0 / s;
+                inverted = sofa::type::invertMatrix(invW, temp * invS);
+                if (inverted) invW *= invS;
+            }
+        }
+
+        SOFA_UNUSED(inverted);
     }
 
     virtual void resolution(int line, double** w, double* d, double* force, double * /*dFree*/)
@@ -70,6 +91,7 @@ public:
     double m_compliance[3];
     sofa::type::Mat<3,3,double> invW;
     SReal m_frictionCoeff;
+    bool m_scaleComplianceMatrix;
 };
 
 }


### PR DESCRIPTION
More of a hack, less of a fix, to be used for some particular cases.

Depending on how the scene is set up (i.e. scaling, physical parameters, units) the block with the compliances might have a low-magnitude determinant. In `invertMatrix()` there is a check for that magnitude. If it's too small, it gets rejected and we end up with a null matrix. 

Normally, we should build scenes properly and scale them well. However there can be situations where this is not possible (Unity pipeline, haptics scale etc). So the PR adds the option to scale the matrix before inverting it. Default is false. 

